### PR TITLE
Supports sending request bodies

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Monadic Ajax module
 // type Config = {
 //   url : String,
 //   method : String,
+//   body [OPTIONAL] : String,
 //   responseType [OPTIONAL] : String
 //   timeout [OPTIONAL] : Number,
 //   withCredentials [OPTIONAL] : Bool

--- a/src/flapjax.js
+++ b/src/flapjax.js
@@ -52,7 +52,7 @@ export default function flapjax(opts) {
     xhr = setHeaders(opts.headers || {}, xhr);
     xhr = setEvents(opts.events || {}, xhr);
     xhr.addEventListener('readystatechange', onStateChange(xhr), false);
-    xhr.send();
+    xhr.send(opts.body);
     
     return () => {
       if (xhr.readyState < xhr.DONE) {


### PR DESCRIPTION
Hello!

It might be useful to send some data along with the request, so here's a "body" option.